### PR TITLE
fix createNote bug in LinkedNoteStoreClient; 

### DIFF
--- a/src/main/java/com/evernote/clients/BusinessNoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/BusinessNoteStoreClient.java
@@ -1,27 +1,24 @@
 /*
- * Copyright 2012 Evernote Corporation.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright 2012 Evernote Corporation. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.evernote.clients;
 
@@ -32,18 +29,18 @@ import com.evernote.edam.error.EDAMNotFoundException;
 import com.evernote.edam.error.EDAMSystemException;
 import com.evernote.edam.error.EDAMUserException;
 import com.evernote.edam.type.LinkedNotebook;
+import com.evernote.edam.type.Note;
 import com.evernote.edam.type.Notebook;
 import com.evernote.edam.type.SharedNotebook;
 import com.evernote.edam.userstore.AuthenticationResult;
 import com.evernote.thrift.TException;
 
 /**
- * This is a wrapper/helper class that manages the connection to a business
- * notestore. It maintains two {@link AsyncLinkedNoteStoreClient} objects, one
- * points to the users personal store and the other to the business shard.
+ * This is a wrapper/helper class that manages the connection to a business notestore. It maintains
+ * two {@link AsyncLinkedNoteStoreClient} objects, one points to the users personal store and the
+ * other to the business shard.
  * 
- * These helper methods make network calls across both shards to return the
- * appropriate data.
+ * These helper methods make network calls across both shards to return the appropriate data.
  * 
  * @author @tylersmithnet
  * @author kentaro suzuki
@@ -51,8 +48,7 @@ import com.evernote.thrift.TException;
 public class BusinessNoteStoreClient extends LinkedNoteStoreClient {
 
   BusinessNoteStoreClient(NoteStoreClient mainNoteStoreClient,
-      NoteStoreClient linkedNoteStoreClient,
-      AuthenticationResult authenticationResult) {
+      NoteStoreClient linkedNoteStoreClient, AuthenticationResult authenticationResult) {
     super(mainNoteStoreClient, linkedNoteStoreClient, authenticationResult);
   }
 
@@ -66,16 +62,44 @@ public class BusinessNoteStoreClient extends LinkedNoteStoreClient {
 
     Notebook originalNotebook = getClient().createNotebook(notebook);
 
-    SharedNotebook sharedNotebook = originalNotebook.getSharedNotebooks()
-        .get(0);
+    SharedNotebook sharedNotebook = originalNotebook.getSharedNotebooks().get(0);
     LinkedNotebook linkedNotebook = new LinkedNotebook();
     linkedNotebook.setShareKey(sharedNotebook.getShareKey());
     linkedNotebook.setShareName(originalNotebook.getName());
-    linkedNotebook.setUsername(getAuthenticationResult().getUser()
-        .getUsername());
+    linkedNotebook.setUsername(getAuthenticationResult().getUser().getUsername());
     linkedNotebook.setShardId(getAuthenticationResult().getUser().getShardId());
 
     return getPersonalClient().createLinkedNotebook(linkedNotebook);
+  }
+
+  /**
+   * Helper method to create a note in a linked notebook
+   * 
+   * @param note
+   * @param linkedNotebook
+   * @return
+   * @throws com.evernote.edam.error.EDAMUserException
+   * 
+   * @throws com.evernote.edam.error.EDAMSystemException
+   * 
+   * @throws com.evernote.thrift.TException
+   * @throws com.evernote.edam.error.EDAMNotFoundException
+   * 
+   */
+  public Note createNote(Note note, LinkedNotebook linkedNotebook)
+      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {
+
+    AuthenticationResult shareAuthResult =
+        getClient().getClient().authenticateToSharedNotebook(
+            linkedNotebook.getShareKey(), getPersonalClient().getToken());
+
+    SharedNotebook sharedNotebook =
+        getClient().getClient().getSharedNotebookByAuth(
+            shareAuthResult.getAuthenticationToken());
+
+    note.setNotebookGuid(sharedNotebook.getNotebookGuid());
+    return getClient().createNote(note);
+
   }
 
   /**

--- a/src/main/java/com/evernote/clients/ClientFactory.java
+++ b/src/main/java/com/evernote/clients/ClientFactory.java
@@ -156,6 +156,34 @@ public class ClientFactory {
         linkedNoteStoreClient, businessAuthResult);
   }
 
+  
+  /**
+   * Create a new Business NoteStore client. Each call to this method will
+   * return a new NoteStore.Client instance. The returned client can be used for
+   * any number of API calls, but is NOT thread safe.
+   * 
+   * This method will check expiration time for the business authorization
+   * token, this is a network request
+   * 
+   * This method is synchronous
+   * 
+   * @param  businessAuthResult  
+   * @throws TException
+   * @throws EDAMUserException
+   * @throws EDAMSystemException
+   *           User is not part of a business
+   */
+  public BusinessNoteStoreClient createBusinessNoteStoreClient(AuthenticationResult businessAuthResult)
+      throws TException, EDAMUserException, EDAMSystemException {    
+    NoteStoreClient mainNoteStoreClient = createNoteStoreClient();   
+    NoteStoreClient linkedNoteStoreClient = createStoreClient(
+        NoteStoreClient.class, businessAuthResult.getNoteStoreUrl(),
+        businessAuthResult.getAuthenticationToken());
+    return new BusinessNoteStoreClient(mainNoteStoreClient,
+        linkedNoteStoreClient, businessAuthResult);
+  }
+  
+  
   /**
    * @param clientClass
    * @param url

--- a/src/main/java/com/evernote/clients/ClientFactory.java
+++ b/src/main/java/com/evernote/clients/ClientFactory.java
@@ -1,27 +1,24 @@
 /*
- * Copyright 2012 Evernote Corporation
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright 2012 Evernote Corporation All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.evernote.clients;
 
@@ -52,8 +49,7 @@ import com.evernote.thrift.transport.TTransportException;
 public class ClientFactory {
 
   private static final String USER_AGENT_KEY = "User-Agent";
-  private static final Pattern CONSUMER_KEY_REGEX = Pattern
-      .compile(":A=([^:]+):");
+  private static final Pattern CONSUMER_KEY_REGEX = Pattern.compile(":A=([^:]+):");
 
   private EvernoteAuth evernoteAuth;
   private String userAgent;
@@ -70,28 +66,24 @@ public class ClientFactory {
   }
 
   /**
-   * Create a new UserStore client. Each call to this method will return a new
-   * UserStore.Client instance. The returned client can be used for any number
-   * of API calls, but is NOT thread safe.
+   * Create a new UserStore client. Each call to this method will return a new UserStore.Client
+   * instance. The returned client can be used for any number of API calls, but is NOT thread safe.
    * 
-   * @param url
-   *          to connect to
+   * @param url to connect to
    * 
-   * @throws TTransportException
-   *           if an error occurs setting up the connection to the Evernote
+   * @throws TTransportException if an error occurs setting up the connection to the Evernote
    *           service.
    * 
    */
   public UserStoreClient createUserStoreClient() throws TTransportException {
     String serviceUrl = this.evernoteAuth.getUserStoreUrl();
-    return createStoreClient(UserStoreClient.class, serviceUrl,
-        this.evernoteAuth.getToken());
+    return createStoreClient(UserStoreClient.class, serviceUrl, this.evernoteAuth
+        .getToken());
   }
 
   /**
-   * Create a new NoteStore client. Each call to this method will return a new
-   * NoteStore.Client instance. The returned client can be used for any number
-   * of API calls, but is NOT thread safe.
+   * Create a new NoteStore client. Each call to this method will return a new NoteStore.Client
+   * instance. The returned client can be used for any number of API calls, but is NOT thread safe.
    * 
    * @throws TException
    * @throws EDAMSystemException
@@ -104,8 +96,8 @@ public class ClientFactory {
       noteStoreUrl = createUserStoreClient().getNoteStoreUrl();
       this.evernoteAuth.setNoteStoreUrl(noteStoreUrl);
     }
-    return createStoreClient(NoteStoreClient.class, noteStoreUrl,
-        this.evernoteAuth.getToken());
+    return createStoreClient(NoteStoreClient.class, noteStoreUrl, this.evernoteAuth
+        .getToken());
   }
 
   /**
@@ -113,55 +105,56 @@ public class ClientFactory {
    * 
    * @param linkedNotebook
    */
-  public LinkedNoteStoreClient createLinkedNoteStoreClient(
-      LinkedNotebook linkedNotebook) throws EDAMUserException,
-      EDAMSystemException, TException, EDAMNotFoundException {
+  public LinkedNoteStoreClient createLinkedNoteStoreClient(LinkedNotebook linkedNotebook)
+      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {
 
     NoteStoreClient mainNoteStoreClient = createNoteStoreClient();
-    
-    //authenticate to remote sharedNotebook object according to the shareKey of this linkedNotebook
+
+    // authenticate to remote sharedNotebook object according to the shareKey of this linkedNotebook
     THttpClient noteStoreTrans;
     noteStoreTrans = new THttpClient(linkedNotebook.getNoteStoreUrl());
     TBinaryProtocol noteStoreProt = new TBinaryProtocol(noteStoreTrans);
-    NoteStore.Client tmpLinkedNoteStoreClient = new NoteStore.Client(noteStoreProt, noteStoreProt);
-    
-    AuthenticationResult sharedAuth = tmpLinkedNoteStoreClient.authenticateToSharedNotebook(linkedNotebook.getShareKey(), mainNoteStoreClient.getToken());
-    
-    NoteStoreClient linkedNoteStoreClient = createStoreClient(
-        NoteStoreClient.class, linkedNotebook.getNoteStoreUrl(),
-        sharedAuth.getAuthenticationToken());
-    
-    return new LinkedNoteStoreClient(mainNoteStoreClient,
-        linkedNoteStoreClient, sharedAuth);
+    NoteStore.Client tmpLinkedNoteStoreClient =
+        new NoteStore.Client(noteStoreProt, noteStoreProt);
+
+    AuthenticationResult sharedAuth =
+        tmpLinkedNoteStoreClient.authenticateToSharedNotebook(linkedNotebook
+            .getShareKey(), mainNoteStoreClient.getToken());
+
+    NoteStoreClient linkedNoteStoreClient =
+        createStoreClient(NoteStoreClient.class, linkedNotebook.getNoteStoreUrl(),
+            sharedAuth.getAuthenticationToken());
+
+    return new LinkedNoteStoreClient(mainNoteStoreClient, linkedNoteStoreClient,
+        sharedAuth);
   }
 
   /**
-   * Create a new Business NoteStore client. Each call to this method will
-   * return a new NoteStore.Client instance. The returned client can be used for
-   * any number of API calls, but is NOT thread safe.
+   * Create a new Business NoteStore client. Each call to this method will return a new
+   * NoteStore.Client instance. The returned client can be used for any number of API calls, but is
+   * NOT thread safe.
    * 
-   * This method will check expiration time for the business authorization
-   * token, this is a network request
+   * This method will check expiration time for the business authorization token, this is a network
+   * request
    * 
    * This method is synchronous
    * 
    * @throws TException
    * @throws EDAMUserException
-   * @throws EDAMSystemException
-   *           User is not part of a business
+   * @throws EDAMSystemException User is not part of a business
    */
-  public BusinessNoteStoreClient createBusinessNoteStoreClient()
-      throws TException, EDAMUserException, EDAMSystemException {
+  public BusinessNoteStoreClient createBusinessNoteStoreClient() throws TException,
+      EDAMUserException, EDAMSystemException {
 
     NoteStoreClient mainNoteStoreClient = createNoteStoreClient();
-    AuthenticationResult businessAuthResult = createUserStoreClient()
-        .authenticateToBusiness();
-    NoteStoreClient linkedNoteStoreClient = createStoreClient(
-        NoteStoreClient.class, businessAuthResult.getNoteStoreUrl(),
-        businessAuthResult.getAuthenticationToken());
+    AuthenticationResult businessAuthResult =
+        createUserStoreClient().authenticateToBusiness();
+    NoteStoreClient linkedNoteStoreClient =
+        createStoreClient(NoteStoreClient.class, businessAuthResult.getNoteStoreUrl(),
+            businessAuthResult.getAuthenticationToken());
 
-    return new BusinessNoteStoreClient(mainNoteStoreClient,
-        linkedNoteStoreClient, businessAuthResult);
+    return new BusinessNoteStoreClient(mainNoteStoreClient, linkedNoteStoreClient,
+        businessAuthResult);
   }
 
   /**
@@ -184,8 +177,8 @@ public class ClientFactory {
 
     TProtocol protocol = new TBinaryProtocol(transport);
     try {
-      return clientClass.getDeclaredConstructor(TProtocol.class,
-          TProtocol.class, String.class).newInstance(protocol, protocol, token);
+      return clientClass.getDeclaredConstructor(TProtocol.class, TProtocol.class,
+          String.class).newInstance(protocol, protocol, token);
     } catch (Throwable e) {
       throw new RuntimeException("Couldn't create " + clientClass.getName()
           + " due to the error.", e);
@@ -199,8 +192,7 @@ public class ClientFactory {
     String id = userAgent;
     if (id == null) {
       Matcher matcher = CONSUMER_KEY_REGEX.matcher(evernoteAuth.getToken());
-      if (matcher.find() && matcher.groupCount() >= 1
-          && matcher.group(1) != null) {
+      if (matcher.find() && matcher.groupCount() >= 1 && matcher.group(1) != null) {
         id = matcher.group(1);
       } else {
         id = "";
@@ -209,8 +201,7 @@ public class ClientFactory {
 
     String sdkVersion = getClass().getPackage().getImplementationVersion();
     if (sdkVersion == null) {
-      sdkVersion = Constants.EDAM_VERSION_MAJOR + "."
-          + Constants.EDAM_VERSION_MINOR;
+      sdkVersion = Constants.EDAM_VERSION_MAJOR + "." + Constants.EDAM_VERSION_MINOR;
     }
     String javaVersion = System.getProperty("java.version");
     return id + " / " + sdkVersion + "; Java / " + javaVersion;

--- a/src/main/java/com/evernote/clients/ClientFactory.java
+++ b/src/main/java/com/evernote/clients/ClientFactory.java
@@ -156,34 +156,6 @@ public class ClientFactory {
         linkedNoteStoreClient, businessAuthResult);
   }
 
-  
-  /**
-   * Create a new Business NoteStore client. Each call to this method will
-   * return a new NoteStore.Client instance. The returned client can be used for
-   * any number of API calls, but is NOT thread safe.
-   * 
-   * This method will check expiration time for the business authorization
-   * token, this is a network request
-   * 
-   * This method is synchronous
-   * 
-   * @param  businessAuthResult  
-   * @throws TException
-   * @throws EDAMUserException
-   * @throws EDAMSystemException
-   *           User is not part of a business
-   */
-  public BusinessNoteStoreClient createBusinessNoteStoreClient(AuthenticationResult businessAuthResult)
-      throws TException, EDAMUserException, EDAMSystemException {    
-    NoteStoreClient mainNoteStoreClient = createNoteStoreClient();   
-    NoteStoreClient linkedNoteStoreClient = createStoreClient(
-        NoteStoreClient.class, businessAuthResult.getNoteStoreUrl(),
-        businessAuthResult.getAuthenticationToken());
-    return new BusinessNoteStoreClient(mainNoteStoreClient,
-        linkedNoteStoreClient, businessAuthResult);
-  }
-  
-  
   /**
    * @param clientClass
    * @param url

--- a/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
@@ -72,15 +72,15 @@ public class LinkedNoteStoreClient {
     return linkedNoteStoreClient;
   }
 
-  NoteStoreClient getPersonalClient() {
+  public NoteStoreClient getPersonalClient() {
     return mainNoteStoreClient;
   }
 
-  AuthenticationResult getAuthenticationResult() {
+  public AuthenticationResult getAuthenticationResult() {
     return authenticationResult;
   }
 
-  String getToken() {
+  public String getToken() {
     return getAuthenticationResult().getAuthenticationToken();
   }
 
@@ -99,15 +99,28 @@ public class LinkedNoteStoreClient {
    * 
    */
   public Note createNote(Note note, LinkedNotebook linkedNotebook)
-      throws EDAMUserException, EDAMSystemException, TException,
-      EDAMNotFoundException {
-
-    SharedNotebook sharedNotebook = getClient().getSharedNotebookByAuth();
-    note.setNotebookGuid(sharedNotebook.getNotebookGuid());
+      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {  
+    note.setNotebookGuid(getSharedNotebookGuid(linkedNotebook));
     return getClient().createNote(note);
-
   }
 
+  
+  /**
+   * Helper method to get Shared Notebook's GUID
+   * 
+   **/  
+  public String getSharedNotebookGuid(LinkedNotebook linkedNotebook)
+      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {
+    AuthenticationResult shareAuthResult =
+        linkedNoteStoreClient.getClient().authenticateToSharedNotebook(linkedNotebook
+            .getShareKey(), mainNoteStoreClient.getToken());
+    SharedNotebook sharedNotebook =
+        linkedNoteStoreClient.getClient().getSharedNotebookByAuth(shareAuthResult
+            .getAuthenticationToken());
+    return sharedNotebook.getNotebookGuid();
+  }
+  
+  
   /**
    * Helper method to list linked notebooks
    * 

--- a/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
@@ -1,27 +1,24 @@
 /*
- * Copyright 2012 Evernote Corporation.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright 2012 Evernote Corporation. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.evernote.clients;
 
@@ -38,9 +35,9 @@ import com.evernote.edam.userstore.AuthenticationResult;
 import com.evernote.thrift.TException;
 
 /**
- * This is a wrapper/helper class that manages the connection to a linked
- * notestore. It maintains two {@link LinkedNoteStoreClient} objects, one points
- * to the users personal store and the other to linked notebooks shard.
+ * This is a wrapper/helper class that manages the connection to a linked notestore. It maintains
+ * two {@link LinkedNoteStoreClient} objects, one points to the users personal store and the other
+ * to linked notebooks shard.
  * 
  * 
  * @author @tylersmithnet
@@ -55,16 +52,14 @@ public class LinkedNoteStoreClient {
   private AuthenticationResult authenticationResult;
 
   LinkedNoteStoreClient(NoteStoreClient mainNoteStoreClient,
-      NoteStoreClient linkedNoteStoreClient,
-      AuthenticationResult authenticationResult) {
+      NoteStoreClient linkedNoteStoreClient, AuthenticationResult authenticationResult) {
     this.mainNoteStoreClient = mainNoteStoreClient;
     this.linkedNoteStoreClient = linkedNoteStoreClient;
     this.authenticationResult = authenticationResult;
   }
 
   /**
-   * Returns the {@link NoteStoreClient} object that has been instantiated to
-   * the appropriate shard
+   * Returns the {@link NoteStoreClient} object that has been instantiated to the appropriate shard
    * 
    * @return
    */
@@ -98,9 +93,8 @@ public class LinkedNoteStoreClient {
    * @throws com.evernote.edam.error.EDAMNotFoundException
    * 
    */
-  public Note createNote(Note note)
-      throws EDAMUserException, EDAMSystemException, TException,
-      EDAMNotFoundException {
+  public Note createNote(Note note) throws EDAMUserException, EDAMSystemException,
+      TException, EDAMNotFoundException {
 
     SharedNotebook sharedNotebook = getClient().getSharedNotebookByAuth();
     note.setNotebookGuid(sharedNotebook.getNotebookGuid());
@@ -126,8 +120,7 @@ public class LinkedNoteStoreClient {
    * @param linkedNotebook
    */
   public Notebook getCorrespondingNotebook(LinkedNotebook linkedNotebook)
-      throws TException, EDAMUserException, EDAMSystemException,
-      EDAMNotFoundException {
+      throws TException, EDAMUserException, EDAMSystemException, EDAMNotFoundException {
     SharedNotebook sharedNotebook = getClient().getSharedNotebookByAuth();
     return getClient().getNotebook(sharedNotebook.getNotebookGuid());
   }
@@ -138,8 +131,7 @@ public class LinkedNoteStoreClient {
    * @param linkedNotebook
    */
   public boolean isNotebookWritable(LinkedNotebook linkedNotebook)
-      throws EDAMUserException, TException, EDAMSystemException,
-      EDAMNotFoundException {
+      throws EDAMUserException, TException, EDAMSystemException, EDAMNotFoundException {
     Notebook notebook = getCorrespondingNotebook(linkedNotebook);
     return !notebook.getRestrictions().isNoCreateNotes();
   }

--- a/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
@@ -72,15 +72,15 @@ public class LinkedNoteStoreClient {
     return linkedNoteStoreClient;
   }
 
-  public NoteStoreClient getPersonalClient() {
+  NoteStoreClient getPersonalClient() {
     return mainNoteStoreClient;
   }
 
-  public AuthenticationResult getAuthenticationResult() {
+  AuthenticationResult getAuthenticationResult() {
     return authenticationResult;
   }
 
-  public String getToken() {
+  String getToken() {
     return getAuthenticationResult().getAuthenticationToken();
   }
 
@@ -99,28 +99,15 @@ public class LinkedNoteStoreClient {
    * 
    */
   public Note createNote(Note note, LinkedNotebook linkedNotebook)
-      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {  
-    note.setNotebookGuid(getSharedNotebookGuid(linkedNotebook));
+      throws EDAMUserException, EDAMSystemException, TException,
+      EDAMNotFoundException {
+
+    SharedNotebook sharedNotebook = getClient().getSharedNotebookByAuth();
+    note.setNotebookGuid(sharedNotebook.getNotebookGuid());
     return getClient().createNote(note);
+
   }
 
-  
-  /**
-   * Helper method to get Shared Notebook's GUID
-   * 
-   **/  
-  public String getSharedNotebookGuid(LinkedNotebook linkedNotebook)
-      throws EDAMUserException, EDAMSystemException, TException, EDAMNotFoundException {
-    AuthenticationResult shareAuthResult =
-        linkedNoteStoreClient.getClient().authenticateToSharedNotebook(linkedNotebook
-            .getShareKey(), mainNoteStoreClient.getToken());
-    SharedNotebook sharedNotebook =
-        linkedNoteStoreClient.getClient().getSharedNotebookByAuth(shareAuthResult
-            .getAuthenticationToken());
-    return sharedNotebook.getNotebookGuid();
-  }
-  
-  
   /**
    * Helper method to list linked notebooks
    * 

--- a/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/LinkedNoteStoreClient.java
@@ -98,7 +98,7 @@ public class LinkedNoteStoreClient {
    * @throws com.evernote.edam.error.EDAMNotFoundException
    * 
    */
-  public Note createNote(Note note, LinkedNotebook linkedNotebook)
+  public Note createNote(Note note)
       throws EDAMUserException, EDAMSystemException, TException,
       EDAMNotFoundException {
 

--- a/src/main/java/com/evernote/clients/NoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/NoteStoreClient.java
@@ -100,7 +100,7 @@ public class NoteStoreClient {
   /**
    * @return authToken inserted into calls
    */
-  public String getToken() {
+  String getToken() {
     return token;
   }
 

--- a/src/main/java/com/evernote/clients/NoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/NoteStoreClient.java
@@ -100,7 +100,7 @@ public class NoteStoreClient {
   /**
    * @return authToken inserted into calls
    */
-  String getToken() {
+  public String getToken() {
     return token;
   }
 

--- a/src/main/java/com/evernote/clients/NoteStoreClient.java
+++ b/src/main/java/com/evernote/clients/NoteStoreClient.java
@@ -87,6 +87,15 @@ public class NoteStoreClient {
     this.token = token;
   }
 
+  NoteStoreClient(TProtocol iprot, TProtocol oprot) {
+    if (iprot == null || oprot == null) {
+      throw new IllegalArgumentException(
+          "TProtocol and Token must not be null.");
+    }
+    this.client = new NoteStore.Client(iprot, oprot);
+    this.token = null;
+  }
+  
   /**
    * If direct access to the Note Store is needed, all of these calls are
    * synchronous

--- a/src/test/java/com/evernote/clients/BusinessNoteStoreClientTest.java
+++ b/src/test/java/com/evernote/clients/BusinessNoteStoreClientTest.java
@@ -27,12 +27,7 @@ package com.evernote.clients;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
@@ -41,51 +36,22 @@ import org.junit.Test;
 import com.evernote.auth.EvernoteAuth;
 import com.evernote.auth.EvernoteService;
 import com.evernote.edam.type.LinkedNotebook;
+import com.evernote.edam.type.Note;
 import com.evernote.edam.type.Notebook;
-import com.evernote.edam.type.SharedNotebook;
-import com.evernote.edam.type.User;
-import com.evernote.edam.userstore.AuthenticationResult;
 
 public class BusinessNoteStoreClientTest {
 
-  // If set, test with actual API calls
+  //Please set developer token before testing
   String token = null;
 
   BusinessNoteStoreClient client;
 
   @Before
   public void initialize() throws Exception {
-    if (token == null) {
-      NoteStoreClient noteStoreClient = mock(NoteStoreClient.class);
-
-      SharedNotebook sharedNotebook = new SharedNotebook();
-
-      Notebook createdNotebook = new Notebook();
-      createdNotebook.setSharedNotebooks(Arrays.asList(sharedNotebook));
-      stub(noteStoreClient.createNotebook(isA(Notebook.class))).toReturn(
-          createdNotebook);
-
-      NoteStoreClient personalClient = mock(NoteStoreClient.class);
-
-      List<LinkedNotebook> listLinkedNotebooks = new ArrayList<LinkedNotebook>();
-      stub(personalClient.listLinkedNotebooks()).toReturn(listLinkedNotebooks);
-
-      LinkedNotebook createdLinkedNotebook = new LinkedNotebook();
-      stub(personalClient.createLinkedNotebook(isA(LinkedNotebook.class)))
-          .toReturn(createdLinkedNotebook);
-
-      User user = new User();
-      user.setUsername("username");
-      user.setShardId("shardId");
-      AuthenticationResult authenticationResult = new AuthenticationResult();
-      authenticationResult.setUser(user);
-
-      client = new BusinessNoteStoreClient(personalClient, noteStoreClient,
-          authenticationResult);
-    } else {
-      EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
-      client = new ClientFactory(auth).createBusinessNoteStoreClient();
-    }
+    assertNotNull(token);
+    
+    EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
+    client = new ClientFactory(auth).createBusinessNoteStoreClient();    
   }
 
   @Test
@@ -102,6 +68,21 @@ public class BusinessNoteStoreClientTest {
     for (LinkedNotebook linkedNotebook : listLinkedNotebooks) {
       assertTrue(linkedNotebook.isSetBusinessId());
     }
+  }
+  
+  @Test
+  public void testCreateNote() throws Exception {
+    Note note = new Note();
+    note.setTitle("BusinessNoteStoreClientTest#testCreateNote");
+    note.setContent("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<!DOCTYPE en-note SYSTEM \"http://xml.evernote.com/pub/enml2.dtd\">"
+        + "<en-note>" + "TEST" + "</en-note>");    
+    
+    List<LinkedNotebook> listLinkedNotebooks = client.listNotebooks();    
+    assertNotNull(listLinkedNotebooks);  
+    
+    Note createdNote = client.createNote(note, listLinkedNotebooks.get(0));
+    assertNotNull(createdNote.getGuid());
   }
 
 }

--- a/src/test/java/com/evernote/clients/BusinessNoteStoreClientTest.java
+++ b/src/test/java/com/evernote/clients/BusinessNoteStoreClientTest.java
@@ -1,33 +1,35 @@
 /*
- * Copyright 2013 Evernote Corporation
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright 2013 Evernote Corporation All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.evernote.clients;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stub;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
@@ -36,22 +38,51 @@ import org.junit.Test;
 import com.evernote.auth.EvernoteAuth;
 import com.evernote.auth.EvernoteService;
 import com.evernote.edam.type.LinkedNotebook;
-import com.evernote.edam.type.Note;
 import com.evernote.edam.type.Notebook;
+import com.evernote.edam.type.SharedNotebook;
+import com.evernote.edam.type.User;
+import com.evernote.edam.userstore.AuthenticationResult;
 
 public class BusinessNoteStoreClientTest {
 
-  //Please set developer token before testing
+  // If set, test with actual API calls
   String token = null;
 
   BusinessNoteStoreClient client;
 
   @Before
   public void initialize() throws Exception {
-    assertNotNull(token);
-    
-    EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
-    client = new ClientFactory(auth).createBusinessNoteStoreClient();    
+    if (token == null) {
+      NoteStoreClient noteStoreClient = mock(NoteStoreClient.class);
+
+      SharedNotebook sharedNotebook = new SharedNotebook();
+
+      Notebook createdNotebook = new Notebook();
+      createdNotebook.setSharedNotebooks(Arrays.asList(sharedNotebook));
+      stub(noteStoreClient.createNotebook(isA(Notebook.class))).toReturn(createdNotebook);
+
+      NoteStoreClient personalClient = mock(NoteStoreClient.class);
+
+      List<LinkedNotebook> listLinkedNotebooks = new ArrayList<LinkedNotebook>();
+      stub(personalClient.listLinkedNotebooks()).toReturn(listLinkedNotebooks);
+
+      LinkedNotebook createdLinkedNotebook = new LinkedNotebook();
+      stub(personalClient.createLinkedNotebook(isA(LinkedNotebook.class))).toReturn(
+          createdLinkedNotebook);
+
+      User user = new User();
+      user.setUsername("username");
+      user.setShardId("shardId");
+      AuthenticationResult authenticationResult = new AuthenticationResult();
+      authenticationResult.setUser(user);
+
+      client =
+          new BusinessNoteStoreClient(personalClient, noteStoreClient,
+              authenticationResult);
+    } else {
+      EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
+      client = new ClientFactory(auth).createBusinessNoteStoreClient();
+    }
   }
 
   @Test
@@ -68,21 +99,6 @@ public class BusinessNoteStoreClientTest {
     for (LinkedNotebook linkedNotebook : listLinkedNotebooks) {
       assertTrue(linkedNotebook.isSetBusinessId());
     }
-  }
-  
-  @Test
-  public void testCreateNote() throws Exception {
-    Note note = new Note();
-    note.setTitle("BusinessNoteStoreClientTest#testCreateNote");
-    note.setContent("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        + "<!DOCTYPE en-note SYSTEM \"http://xml.evernote.com/pub/enml2.dtd\">"
-        + "<en-note>" + "TEST" + "</en-note>");    
-    
-    List<LinkedNotebook> listLinkedNotebooks = client.listNotebooks();    
-    assertNotNull(listLinkedNotebooks);  
-    
-    Note createdNote = client.createNote(note, listLinkedNotebooks.get(0));
-    assertNotNull(createdNote.getGuid());
   }
 
 }

--- a/src/test/java/com/evernote/clients/LinkedNoteStoreClientTest.java
+++ b/src/test/java/com/evernote/clients/LinkedNoteStoreClientTest.java
@@ -1,38 +1,30 @@
 /*
- * Copyright 2013 Evernote Corporation
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright 2013 Evernote Corporation All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.evernote.clients;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
@@ -43,61 +35,24 @@ import com.evernote.auth.EvernoteService;
 import com.evernote.edam.type.LinkedNotebook;
 import com.evernote.edam.type.Note;
 import com.evernote.edam.type.Notebook;
-import com.evernote.edam.type.NotebookRestrictions;
-import com.evernote.edam.type.SharedNotebook;
-import com.evernote.edam.userstore.AuthenticationResult;
 
 public class LinkedNoteStoreClientTest {
 
-  // If set, test with actual API calls
+  // Please set developer token before testing
   String token = null;
 
   LinkedNotebook linkedNotebook = null;
   LinkedNoteStoreClient client;
 
   @Before
-  public void initialize() throws Exception {
-    if (token == null) {
-      client = mock(LinkedNoteStoreClient.class);
+  public void initialize() throws Exception {    
+    assertNotNull(token);
 
-      NoteStoreClient noteStoreClient = mock(NoteStoreClient.class);
+    EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
+    ClientFactory factory = new ClientFactory(auth);
+    linkedNotebook = factory.createNoteStoreClient().listLinkedNotebooks().get(0);
+    client = factory.createLinkedNoteStoreClient(linkedNotebook);
 
-      Note createdNote = new Note();
-      createdNote.setGuid("guid");
-      stub(noteStoreClient.createNote(isA(Note.class))).toReturn(createdNote);
-
-      NotebookRestrictions restrictions = new NotebookRestrictions();
-      restrictions.setNoCreateNotes(false);
-
-      Notebook createdNotebook = new Notebook();
-      createdNotebook.setRestrictions(restrictions);
-      stub(noteStoreClient.createNotebook(isA(Notebook.class))).toReturn(
-          createdNotebook);
-      stub(noteStoreClient.getNotebook(anyString())).toReturn(createdNotebook);
-
-      SharedNotebook sharedNotebook = new SharedNotebook();
-      stub(noteStoreClient.getSharedNotebookByAuth()).toReturn(sharedNotebook);
-
-      NoteStoreClient personalClient = mock(NoteStoreClient.class);
-
-      List<LinkedNotebook> listLinkedNotebooks = new ArrayList<LinkedNotebook>();
-      stub(personalClient.listLinkedNotebooks()).toReturn(listLinkedNotebooks);
-
-      LinkedNotebook createdLinkedNotebook = new LinkedNotebook();
-      stub(personalClient.createLinkedNotebook(isA(LinkedNotebook.class)))
-          .toReturn(createdLinkedNotebook);
-
-      AuthenticationResult authenticationResult = new AuthenticationResult();
-
-      client = new LinkedNoteStoreClient(personalClient, noteStoreClient,
-          authenticationResult);
-    } else {
-      EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);
-      ClientFactory factory = new ClientFactory(auth);
-      linkedNotebook = factory.createNoteStoreClient().listLinkedNotebooks()
-          .get(0);
-      client = factory.createLinkedNoteStoreClient(linkedNotebook);
-    }
   }
 
   @Test
@@ -107,7 +62,7 @@ public class LinkedNoteStoreClientTest {
     note.setContent("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<!DOCTYPE en-note SYSTEM \"http://xml.evernote.com/pub/enml2.dtd\">"
         + "<en-note>" + "TEST" + "</en-note>");
-    Note createdNote = client.createNote(note, linkedNotebook);
+    Note createdNote = client.createNote(note);
     assertNotNull(createdNote.getGuid());
   }
 

--- a/src/test/java/com/evernote/clients/LinkedNoteStoreClientTest.java
+++ b/src/test/java/com/evernote/clients/LinkedNoteStoreClientTest.java
@@ -45,7 +45,7 @@ public class LinkedNoteStoreClientTest {
   LinkedNoteStoreClient client;
 
   @Before
-  public void initialize() throws Exception {    
+  public void initialize() throws Exception {
     assertNotNull(token);
 
     EvernoteAuth auth = new EvernoteAuth(EvernoteService.SANDBOX, token);


### PR DESCRIPTION
1. fix createNote bug in LinkedNoteStoreClient; split the createNote to two steps so that developers can reuse Guid of sharedNotebook

2. add createBusinessNoteStoreClient in ClientFactory so that developer can reuse AuthenticationResult; 

3. make some getters public, so that developers can easily inherit and extend classes in the package com.evernote.clients, also make developers easily reuse some source code. 